### PR TITLE
Fix location of installed candidates

### DIFF
--- a/manifests/gradle.pp
+++ b/manifests/gradle.pp
@@ -7,7 +7,7 @@ define sdkman::gradle(
 
   exec { "install-gradle-$name":
     command => "bash --login -c 'sdk install gradle ${version}'",
-    creates => "/Users/${::boxen_user}/.sdkman/gradle/${version}"
+    creates => "/Users/${::boxen_user}/.sdkman/candidates/gradle/${version}"
   }
 
   if($default) {

--- a/manifests/grails.pp
+++ b/manifests/grails.pp
@@ -7,7 +7,7 @@ define sdkman::grails(
 
   exec { "install-grails-$name":
   	command => "bash --login -c 'sdk install grails ${version}'",
-  	creates => "/Users/${::boxen_user}/.sdkman/grails/${version}"
+  	creates => "/Users/${::boxen_user}/.sdkman/candidates/grails/${version}"
   }
 
   if($default) {

--- a/manifests/groovy.pp
+++ b/manifests/groovy.pp
@@ -7,7 +7,7 @@ define sdkman::groovy(
 
   exec { "install-groovy-$name":
   	command => "bash --login -c 'sdk install groovy ${version}'",
-  	creates => "/Users/${::boxen_user}/.sdkman/groovy/${version}"
+  	creates => "/Users/${::boxen_user}/.sdkman/candidates/groovy/${version}"
   }
 
   if($default) {

--- a/manifests/groovyserv.pp
+++ b/manifests/groovyserv.pp
@@ -7,7 +7,7 @@ define sdkman::groovyserv(
 
   exec { "install-groovyserv-$name":
     command => "bash --login -c 'sdk install groovyserv ${version}'",
-    creates => "/Users/${::boxen_user}/.sdkman/groovyserv/${version}"
+    creates => "/Users/${::boxen_user}/.sdkman/candidates/groovyserv/${version}"
   }
 
   if($default) {

--- a/manifests/springboot.pp
+++ b/manifests/springboot.pp
@@ -7,7 +7,7 @@ define sdkman::springboot(
 
   exec { "install-springboot-$name":
     command => "bash --login -c 'sdk install springboot ${version}'",
-    creates => "/Users/${::boxen_user}/.sdkman/springboot/${version}"
+    creates => "/Users/${::boxen_user}/.sdkman/candidates/springboot/${version}"
   }
 
   if($default) {

--- a/manifests/vertx.pp
+++ b/manifests/vertx.pp
@@ -7,7 +7,7 @@ define sdkman::vertx(
 
   exec { "install-vertx-$name":
     command => "bash --login -c 'sdk install vertx ${version}'",
-    creates => "/Users/${::boxen_user}/.sdkman/vertx/${version}"
+    creates => "/Users/${::boxen_user}/.sdkman/candidates/vertx/${version}"
   }
   
   if($default) {


### PR DESCRIPTION
The previous convention put gradle, grails, etc. into ~/.sdkman. Now it is inside ~/.sdkman/candidates and some installs have symlinks to the previous locations. The installs without the symlinks keep trying to install what is already there, although sdkman knows that and doesn't install.
